### PR TITLE
Fix wrong option label of language select

### DIFF
--- a/console/src/editor/text-diagram/TextDiagramView.vue
+++ b/console/src/editor/text-diagram/TextDiagramView.vue
@@ -10,7 +10,16 @@ mermaid.initialize({ startOnLoad: false });
 const props = defineProps(nodeViewProps);
 const previewRef = ref<HTMLElement>();
 
-const languages = ["mermaid", "plantuml"];
+const languages = [
+  {
+    value: "mermaid",
+    label: "Mermaid",
+  },
+  {
+    value: "plantuml",
+    label: "PlantUML",
+  },
+];
 const language = computed({
   get: () => {
     return props.node?.attrs.type;
@@ -75,8 +84,12 @@ onMounted(() => {
           class="text-diagram-type-select block px-2 py-1.5 text-sm text-gray-900 border border-gray-300 rounded-md bg-gray-50 focus:ring-blue-500 focus:border-blue-500"
           contenteditable="false"
         >
-          <option v-for="(lan, index) in languages" :key="index" :value="lan">
-            {{ language }}
+          <option
+            v-for="(lan, index) in languages"
+            :key="index"
+            :value="lan.value"
+          >
+            {{ lan.label }}
           </option>
         </select>
       </div>


### PR DESCRIPTION
before:

<img width="561" alt="图片" src="https://github.com/halo-sigs/plugin-text-diagram/assets/21301288/5b390a33-a39a-46ba-9f40-3264a3836de0">

now:

<img width="581" alt="图片" src="https://github.com/halo-sigs/plugin-text-diagram/assets/21301288/f289388a-d215-4ac4-bf68-a17f9dfe4ab9">

/kind bug

```release-note
修复绘图类型选择的显示文字的问题
```