### PR TITLE
Remove mermaid imports to resolve bundle size issue

### DIFF
--- a/console/env.d.ts
+++ b/console/env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+export {};
+
 declare module "*.vue" {
   declare module "*.vue" {
     // NOTE: ts-loader
@@ -7,5 +9,13 @@ declare module "*.vue" {
 
     const component: ReturnType<typeof defineComponent>;
     export default component;
+  }
+}
+
+import type { Mermaid } from "mermaid";
+
+declare global {
+  interface Window {
+    mermaid: Mermaid;
   }
 }


### PR DESCRIPTION
This PR removes the import of the mermaid dependency and does not build it into the main.js file, as this causes the main.js file to become very large. Additionally, due to the current front-end plugin mechanism of Halo, we cannot use es module and dynamic import, resulting in an increasingly large bundle.js for plugins.

This PR changes the loading of mermaid resources in the editor to be consistent with the loading method used on the theme side.

Before:

<img width="578" alt="image" src="https://github.com/halo-sigs/plugin-text-diagram/assets/21301288/01a60f40-bb81-4a3f-a03d-7256cd4dcfd1">

After:

<img width="570" alt="image" src="https://github.com/halo-sigs/plugin-text-diagram/assets/21301288/cb4139c0-7e63-4909-b893-5d2990cc0a09">

/kind improvement

```release-note
Remove mermaid imports to resolve bundle size issue
```

