### PR TITLE
chore: cleanup deprecated constructor for base plugin

### DIFF
--- a/src/main/java/run/halo/plugin/textdiagram/StarterPlugin.java
+++ b/src/main/java/run/halo/plugin/textdiagram/StarterPlugin.java
@@ -1,31 +1,14 @@
 package run.halo.plugin.textdiagram;
 
-import org.pf4j.PluginWrapper;
 import org.springframework.stereotype.Component;
-import run.halo.app.plugin.BasePlugin;
 
-/**
- * <p>Plugin main class to manage the lifecycle of the plugin.</p>
- * <p>This class must be public and have a public constructor.</p>
- * <p>Only one main class extending {@link BasePlugin} is allowed per plugin.</p>
- *
- * @author guqing
- * @since 1.0.0
- */
+import run.halo.app.plugin.BasePlugin;
+import run.halo.app.plugin.PluginContext;
+
 @Component
 public class StarterPlugin extends BasePlugin {
 
-    public StarterPlugin(PluginWrapper wrapper) {
-        super(wrapper);
-    }
-
-    @Override
-    public void start() {
-        System.out.println("插件启动成功！");
-    }
-
-    @Override
-    public void stop() {
-        System.out.println("插件停止！");
+    public StarterPlugin(PluginContext context) {
+        super(context);
     }
 }


### PR DESCRIPTION
### What this PR does?
移除对已过时的 PluginWrapper 的引用

see also https://github.com/halo-dev/halo/pull/6243

```release-note
None
```