### PR TITLE
fix: prevent unnecessary updates to post snapshot when rendering PlantUML

### DIFF
--- a/console/src/editor/text-diagram/TextDiagramView.vue
+++ b/console/src/editor/text-diagram/TextDiagramView.vue
@@ -61,7 +61,9 @@ const doRenderPreview = async function () {
     }
     case "plantuml": {
       const url = compress(graphDefinition);
-      props.updateAttributes({ src: url });
+      if (props.node.attrs.src !== url) {
+        props.updateAttributes({ src: url });
+      }
       element.innerHTML = `<img src="${url}" alt="plantuml"/>`;
       break;
     }


### PR DESCRIPTION
问题现象：
打开已发布带有PlantUML的文章编辑界面，若干秒后会自动保存一份无差异的快照，退出到文章列表提示`当前有内容已保存，但还未发布`

原因：
渲染时进行了无用的src属性更新，导致被认为文章有变更，被自动保存生成新快照

```release-note
修复进入已发布的带有PlantUML的文章编辑界面后提示有内容已保存但未发布的问题
```