### PR TITLE
pref: support for pre-rendered optimization of performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,17 @@
 
 ## 用法说明
 
-### 默认编辑器
+### 在默认编辑器中使用
 
 可以在指令菜单（/）中找到 **文本绘图** 菜单项，选择即可插入新的文本绘图块。
 
-### 文章页渲染
+> 在默认编辑器中使用时，无需开启客户 Mermaid 端渲染。但如果使用过旧版本的文本绘图，可能需要重新保存文章以更新渲染。
 
-此插件安装之后，支持渲染文本绘图。
+已知问题：由于是预渲染，因此无法切换主题。
+
+### 在第三方编辑器中使用
+
+在第三方编辑器中使用时，需要前往 **插件设置** 中开启客户 Mermaid 端渲染，并设置 mermaid_selector。
 
 配置项：
 1. dark_class_selector
@@ -30,11 +34,11 @@
    
    example：`html[class~=dark],html[data-color-scheme=dark]`
 
-3. mermaid_selector
+2. mermaid_selector
 
    CSS-Selector语法，用来查找渲染的mermaid-Dom。
 
-   默认值为：`text-diagram[data-type="mermaid"]`（本插件扩展默认编辑器生成的行内公式Dom），如需兼容其他编辑器，则设置为相应的Selector即可（CSS-Selector支持或，`,`分隔即可）
+   默认值为：`text-diagram[data-type="mermaid"]`（CSS-Selector支持或，`,`分隔即可）
 
    example：`.class1,.class2`
 

--- a/console/src/editor/text-diagram/TextDiagramView.vue
+++ b/console/src/editor/text-diagram/TextDiagramView.vue
@@ -24,6 +24,15 @@ const languages = [
   },
 ];
 
+const render = computed({
+  get: () => {
+    return props.node.attrs.render;
+  },
+  set: (render: string) => {
+    props.updateAttributes({ render });
+  },
+});
+
 const languageValue = computed({
   get: () => {
     return props.node?.attrs.type;
@@ -39,6 +48,7 @@ const language = computed(() => {
 
 // render as svg
 const doRenderPreview = async function () {
+  console.log("doRenderPreview");
   const element = previewRef.value;
   if (!element) return;
   const graphDefinition = props.node.attrs.content;
@@ -53,18 +63,15 @@ const doRenderPreview = async function () {
           graphDefinition,
           element
         );
-        element.innerHTML = svg;
+        render.value = svg;
       } catch (error) {
-        element.innerHTML = `<pre style="color: red; background-color: #f6f8fa">${error}</pre>`;
+        render.value = `<pre style="color: red; background-color: #f6f8fa">${error}</pre>`;
       }
       break;
     }
     case "plantuml": {
       const url = compress(graphDefinition);
-      if (props.node.attrs.src !== url) {
-        props.updateAttributes({ src: url });
-      }
-      element.innerHTML = `<img src="${url}" alt="plantuml"/>`;
+      render.value = `<img src="${url}" alt="plantuml"/>`;
       break;
     }
     default:
@@ -74,25 +81,29 @@ const doRenderPreview = async function () {
 
 const renderPreview = useDebounceFn(() => doRenderPreview(), 250);
 
-onMounted(async () => {
-  watch(
-    () => props.node.attrs.content,
-    () => {
-      nextTick(() => {
-        renderPreview();
-      });
-    }
-  );
-  watch(
-    () => props.node.attrs.type,
-    () => {
-      nextTick(() => {
-        renderPreview();
-      });
-    }
-  );
+onMounted(() => {
+  if (render.value) {
+    return;
+  }
   renderPreview();
 });
+
+watch(
+  () => props.node.attrs.content,
+  () => {
+    nextTick(() => {
+      renderPreview();
+    });
+  }
+);
+watch(
+  () => props.node.attrs.type,
+  () => {
+    nextTick(() => {
+      renderPreview();
+    });
+  }
+);
 
 // text diagram editor
 function onEditorChange(value: string) {
@@ -147,11 +158,14 @@ function onEditorChange(value: string) {
           @change="onEditorChange"
         />
       </div>
+      <!-- eslint-disable vue/no-v-html -->
       <div
         ref="previewRef"
         class="text-diagram-preview"
         contenteditable="false"
+        v-html="render"
       ></div>
+      <!-- eslint-enable vue/no-v-html -->
     </div>
   </node-view-wrapper>
 </template>

--- a/console/src/editor/text-diagram/index.ts
+++ b/console/src/editor/text-diagram/index.ts
@@ -9,91 +9,90 @@ import {
 import TextDiagramView from "./TextDiagramView.vue";
 import { markRaw } from "vue";
 import icon from "~icons/simple-icons/diagramsdotnet";
+import { ExtensionOptions } from "@halo-dev/richtext-editor/dist/types";
 
-export type TextDiagramOptions = {
-  HTMLAttributes: Record<string, any>;
-};
-
-export const ExtensionTextDiagram = Node.create<TextDiagramOptions>({
+export const ExtensionTextDiagram = Node.create<ExtensionOptions>({
   name: "text-diagram",
   inline: false,
-  content: "",
-  marks: "",
   group: "block",
   code: true,
   atom: true,
-  defining: true,
+
   addAttributes() {
     return {
       type: {
         default: "mermaid",
         parseHTML: (element) => element.getAttribute("data-type"),
         renderHTML: (attributes) => {
-          return !attributes.type
-            ? {}
-            : {
-                "data-type": attributes.type,
-              };
+          return {
+            "data-type": attributes.type,
+          };
         },
       },
       content: {
         default: "",
         parseHTML: (element) => element.getAttribute("data-content"),
         renderHTML: (attributes) => {
-          return !attributes.content
-            ? {}
-            : {
-                "data-content": attributes.content,
-              };
+          return {
+            "data-content": attributes.content,
+          };
         },
       },
-      src: {
-        default: "",
-        parseHTML: (element) => element.getAttribute("data-src"),
-        renderHTML: (attributes) => {
-          return !attributes.src
-            ? {}
-            : {
-                "data-src": attributes.src,
-              };
-        },
+      render: {
+        default: null,
+        rendered: false,
       },
     };
   },
   parseHTML() {
     return [
       {
-        tag: "text-diagram[data-type]",
+        tag: "text-diagram[data-type='mermaid']",
+        getAttrs: (element) => {
+          const firstChild = element.firstElementChild;
+          if (firstChild?.nodeType === 1) {
+            return {
+              render: firstChild.outerHTML,
+            };
+          }
+          return {
+            render: null,
+          };
+        },
+      },
+      {
+        tag: "text-diagram[data-type='plantuml']",
+        getAttrs: (element) => {
+          const firstChild = element.firstElementChild;
+          if (firstChild?.tagName === "IMG") {
+            return {
+              render: firstChild.outerHTML,
+            };
+          }
+          return {
+            render: null,
+          };
+        },
       },
     ];
   },
   renderHTML({ node, HTMLAttributes }) {
-    switch (node.attrs.type) {
-      case "plantuml":
-        return [
-          "text-diagram",
-          mergeAttributes(HTMLAttributes),
-          [
-            "img",
-            {
-              src: HTMLAttributes["data-src"],
-            },
-          ],
-        ];
-      case "mermaid":
-        return [
-          "text-diagram",
-          mergeAttributes(HTMLAttributes),
-          node.attrs.content,
-        ];
-      default:
-        // unknown type
-        return [
-          "text-diagram",
-          mergeAttributes(HTMLAttributes),
-          node.attrs.content,
-        ];
+    const render = node.attrs.render;
+    if (!render) {
+      return [
+        "text-diagram",
+        mergeAttributes(HTMLAttributes),
+        node.attrs.content,
+      ];
     }
+
+    const diagram = document.createElement("text-diagram");
+    diagram.innerHTML = render;
+    diagram.setAttribute("data-type", node.attrs.type);
+    diagram.setAttribute("data-content", node.attrs.content);
+    return {
+      dom: diagram,
+    };
   },
   addNodeView() {
     return VueNodeViewRenderer(TextDiagramView);
@@ -124,7 +123,6 @@ export const ExtensionTextDiagram = Node.create<TextDiagramOptions>({
           },
         ];
       },
-      // 扩展指令项
       getCommandMenuItems() {
         return {
           priority: 100,

--- a/console/src/editor/text-diagram/plantuml/encoder.ts
+++ b/console/src/editor/text-diagram/plantuml/encoder.ts
@@ -12,7 +12,6 @@ export function compress(s: string) {
   // Encoded in UTF-8
   // const utf8 = unescape(encodeURIComponent(s));
   const utf8 = new TextEncoder().encode(s);
-  console.log("UTF-8:" + utf8);
   // Compressed using Deflate algorithm
   const deflate = pako.deflateRaw(utf8, {
     level: 9,

--- a/src/main/java/run/halo/plugin/textdiagram/BasicConfig.java
+++ b/src/main/java/run/halo/plugin/textdiagram/BasicConfig.java
@@ -4,6 +4,7 @@ import lombok.Data;
 
 @Data
 public class BasicConfig {
+    boolean enable_client_mermaid_render;
     String dark_class_selector;
     String mermaid_selector;
 }

--- a/src/main/java/run/halo/plugin/textdiagram/DefaultPostContentHandler.java
+++ b/src/main/java/run/halo/plugin/textdiagram/DefaultPostContentHandler.java
@@ -23,7 +23,9 @@ public class DefaultPostContentHandler implements ReactivePostContentHandler {
     @Override
     public Mono<PostContentContext> handle(PostContentContext contentContext) {
         return reactiveSettingFetcher.fetch("basic", BasicConfig.class).map(basicConfig -> {
-            injectJS(contentContext, basicConfig);
+            if (basicConfig.isEnable_client_mermaid_render()) {
+                injectJS(contentContext, basicConfig);
+            }
             return contentContext;
         }).onErrorResume(e -> {
             log.error("TextDiagram PostContent handle failed", Throwables.getRootCause(e));

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -13,14 +13,14 @@ spec:
           value: "html[class~=dark]"
           help: 用于匹配暗黑模式的CSS选择器
         - $formkit: checkbox
-          label: 启用客户 Mermaid 端渲染
-          help: 仅在使用第三方编辑器时需开启
           name: enable_client_mermaid_render
-          key: enable_client_mermaid_render
           id: enable_client_mermaid_render
+          key: enable_client_mermaid_render
+          label: 启用客户 Mermaid 端渲染
+          help: 使用第三方编辑器时，需要启用此项以确保 Mermaid 正确渲染
           value: false
         - $formkit: text
-          if: $get('enable_client_mermaid_render') === true
+          if: $get(enable_client_mermaid_render).value === true
           name: mermaid_selector
           label: mermaid-CSS选择器
           value: "text-diagram[data-type=mermaid]"

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -12,7 +12,15 @@ spec:
           label: 暗黑模式的选择器
           value: "html[class~=dark]"
           help: 用于匹配暗黑模式的CSS选择器
+        - $formkit: checkbox
+          label: 启用客户 Mermaid 端渲染
+          help: 仅在使用第三方编辑器时需开启
+          name: enable_client_mermaid_render
+          key: enable_client_mermaid_render
+          id: enable_client_mermaid_render
+          value: false
         - $formkit: text
+          if: $get('enable_client_mermaid_render') === true
           name: mermaid_selector
           label: mermaid-CSS选择器
           value: "text-diagram[data-type=mermaid]"


### PR DESCRIPTION
#### What type of PR is this?

/kind improvement

#### What this PR does / why we need it:

使用预渲染的方式重新优化文本绘图。

这样做的好处有如下：

1. 无需在客户端再次引入资源，加快客户端访问速度，减少首屏渲染时间
2. 使用了 PJAX 之类的主题，将不会出现 PJAX 类的问题。
3. 停用插件后，客户端侧不会有任何变化。

before:

编辑器中编辑 -> 保存原始数据 -> 客户端调用 JS -> 渲染文本绘图。

after:

编辑器中编辑 -> 保存渲染后的 `SVG` -> 展示 HTML。

> 为了保证兼容，在插件设置中增加了 启用客户端渲染 的功能，用于支持非默认编辑器。

如果使用默认编辑器，建议升级此插件后，对旧版文本绘图所在的文章或页面，重新保存并发布一次。否则需要启用客户端渲染 功能。

#### How to test it?

默认编辑器：

测试旧版数据在开启客户端渲染后，是否能够正常渲染。
测试新版数据关闭客户端渲染后，是否能够正常在客户端渲染。
测试新版数据开启客户端渲染后，是否与关闭客户端渲染时一致。

其他编辑器：
测试在开启客户端渲染后，是否能够正常渲染。

#### Which issue(s) this PR fixes:

Fixes #22

#### Does this PR introduce a user-facing change?
```release-note
使用预渲染的方式重新优化文本绘图。
```
